### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
-#include <cstdarg>
 #include <cstdint>
 #include <cstdio>
 #include <ctime>
@@ -289,13 +288,13 @@ inline ParseResult parse(std::istream& is)
     return ParseResult(std::move(v), std::move(parser.errorReason()));
 }
 
-inline std::string format(std::stringstream &ss)
+inline std::string format(std::stringstream& ss)
 {
     return ss.str();
 }
 
 template<typename T, typename... Args>
-std::string format(std::stringstream &ss, T &&t, Args&&... args)
+std::string format(std::stringstream& ss, T &&t, Args&&... args)
 {
     ss << std::forward<T>(t);
     return format(ss, std::forward<Args>(args)...);
@@ -354,7 +353,7 @@ inline std::string unescape(const std::string& codepoint)
         buf[0] = '\0';
     }
 
-    return reinterpret_cast<char *>(buf);
+    return reinterpret_cast<char*>(buf);
 }
 
 // Returns true if |s| is integer.
@@ -515,7 +514,7 @@ inline Token Lexer::nextStringDoubleQuote()
         next();
         if (!current(&c) || c != '"') {
             // OK. It's empty string.
-            return Token(TokenType::STRING, std::string(""));
+            return Token(TokenType::STRING, std::string());
         }
 
         next();
@@ -603,7 +602,7 @@ inline Token Lexer::nextStringSingleQuote()
         next();
         if (!current(&c) || c != '\'') {
             // OK. It's empty string.
-            return Token(TokenType::STRING, std::string(""));
+            return Token(TokenType::STRING, std::string());
         }
         next();
         // raw string literal started.

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -505,7 +505,7 @@ inline void Lexer::skipUntilNewLine()
 inline Token Lexer::nextStringDoubleQuote()
 {
     if (!consume('"'))
-        return Token(TokenType::ERROR, "string didn't start with '\"'");
+        return Token(TokenType::ERROR, std::string("string didn't start with '\"'"));
 
     std::string s;
     char c;
@@ -515,7 +515,7 @@ inline Token Lexer::nextStringDoubleQuote()
         next();
         if (!current(&c) || c != '"') {
             // OK. It's empty string.
-            return Token(TokenType::STRING, "");
+            return Token(TokenType::STRING, std::string(""));
         }
 
         next();
@@ -532,7 +532,7 @@ inline Token Lexer::nextStringDoubleQuote()
         next();
         if (c == '\\') {
             if (!current(&c))
-                return Token(TokenType::ERROR, "string has unknown escape sequence");
+                return Token(TokenType::ERROR, std::string("string has unknown escape sequence"));
             next();
             switch (c) {
             case 't': c = '\t'; break;
@@ -547,7 +547,7 @@ inline Token Lexer::nextStringDoubleQuote()
                     codepoint += c;
                     next();
                   } else {
-                    return Token(TokenType::ERROR, "string has unknown escape sequence");
+                    return Token(TokenType::ERROR, std::string("string has unknown escape sequence"));
                   }
                 }
                 s += unescape(codepoint);
@@ -562,7 +562,7 @@ inline Token Lexer::nextStringDoubleQuote()
                 }
                 continue;
             default:
-                return Token(TokenType::ERROR, "string has unknown escape sequence");
+                return Token(TokenType::ERROR, std::string("string has unknown escape sequence"));
             }
         } else if (c == '"') {
             if (multiline) {
@@ -588,13 +588,13 @@ inline Token Lexer::nextStringDoubleQuote()
         s += c;
     }
 
-    return Token(TokenType::ERROR, "string didn't end");
+    return Token(TokenType::ERROR, std::string("string didn't end"));
 }
 
 inline Token Lexer::nextStringSingleQuote()
 {
     if (!consume('\''))
-        return Token(TokenType::ERROR, "string didn't start with '\''?");
+        return Token(TokenType::ERROR, std::string("string didn't start with '\''?"));
 
     std::string s;
     char c;
@@ -603,7 +603,7 @@ inline Token Lexer::nextStringSingleQuote()
         next();
         if (!current(&c) || c != '\'') {
             // OK. It's empty string.
-            return Token(TokenType::STRING, "");
+            return Token(TokenType::STRING, std::string(""));
         }
         next();
         // raw string literal started.
@@ -635,7 +635,7 @@ inline Token Lexer::nextStringSingleQuote()
             continue;
         }
 
-        return Token(TokenType::ERROR, "string didn't end with '\'\'\'' ?");
+        return Token(TokenType::ERROR, std::string("string didn't end with '\'\'\'' ?"));
     }
 
     while (current(&c)) {
@@ -647,7 +647,7 @@ inline Token Lexer::nextStringSingleQuote()
         s += c;
     }
 
-    return Token(TokenType::ERROR, "string didn't end with '\''?");
+    return Token(TokenType::ERROR, std::string("string didn't end with '\''?"));
 }
 
 inline Token Lexer::nextKey()
@@ -660,7 +660,7 @@ inline Token Lexer::nextKey()
     }
 
     if (s.empty())
-        return Token(TokenType::ERROR, "Unknown key format");
+        return Token(TokenType::ERROR, std::string("Unknown key format"));
 
     return Token(TokenType::IDENT, s);
 }
@@ -682,7 +682,7 @@ inline Token Lexer::nextValue()
             return Token(TokenType::BOOL, true);
         if (s == "false")
             return Token(TokenType::BOOL, false);
-        return Token(TokenType::ERROR, "Unknown ident: " + s);
+        return Token(TokenType::ERROR, std::string("Unknown ident: ") + s);
     }
 
     while (current(&c) && (('0' <= c && c <= '9') || c == '.' || c == 'e' || c == 'E' ||
@@ -715,7 +715,7 @@ inline Token Lexer::parseAsTime(const std::string& str)
     int n;
     int YYYY, MM, DD;
     if (sscanf(s, "%d-%d-%d%n", &YYYY, &MM, &DD, &n) != 3)
-        return Token(TokenType::ERROR, "Invalid token");
+        return Token(TokenType::ERROR, std::string("Invalid token"));
 
     if (s[n] == '\0') {
         std::tm t;
@@ -730,14 +730,14 @@ inline Token Lexer::parseAsTime(const std::string& str)
     }
 
     if (s[n] != 'T')
-        return Token(TokenType::ERROR, "Invalid token");
+        return Token(TokenType::ERROR, std::string("Invalid token"));
 
     s = s + n + 1;
 
     int hh, mm;
     double ss; // double for fraction
     if (sscanf(s, "%d:%d:%lf%n", &hh, &mm, &ss, &n) != 3)
-        return Token(TokenType::ERROR, "Invalid token");
+        return Token(TokenType::ERROR, std::string("Invalid token"));
 
     std::tm t;
     t.tm_sec = ss;
@@ -762,10 +762,10 @@ inline Token Lexer::parseAsTime(const std::string& str)
     char pn;
     int oh, om;
     if (sscanf(s, "%c%d:%d", &pn, &oh, &om) != 3)
-        return Token(TokenType::ERROR, "Invalid token");
+        return Token(TokenType::ERROR, std::string("Invalid token"));
 
     if (pn != '+' && pn != '-')
-        return Token(TokenType::ERROR, "Invalid token");
+        return Token(TokenType::ERROR, std::string("Invalid token"));
 
     if (pn == '+') {
         tp -= std::chrono::hours(oh);

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -322,8 +322,11 @@ inline std::string removeDelimiter(const std::string& s)
 
 inline std::string unescape(const std::string& codepoint)
 {
-    std::uint32_t x = strtoll(codepoint.c_str(), nullptr, 16);
-    char buf[8];
+    std::uint32_t x;
+    std::uint8_t buf[8];
+    std::stringstream ss(codepoint);
+
+    ss >> std::hex >> x;
 
     if (x <= 0x7FUL) {
         // 0xxxxxxx
@@ -351,7 +354,7 @@ inline std::string unescape(const std::string& codepoint)
         buf[0] = '\0';
     }
 
-    return buf;
+    return reinterpret_cast<char *>(buf);
 }
 
 // Returns true if |s| is integer.

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -146,9 +146,9 @@ private:
 
 // parse() returns ParseResult.
 struct ParseResult {
-    ParseResult(toml::Value v, std::string errorReason) :
+    ParseResult(toml::Value v, std::string er) :
         value(std::move(v)),
-        errorReason(std::move(errorReason)) {}
+        errorReason(std::move(er)) {}
 
     bool valid() const { return value.valid(); }
 

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -740,7 +740,7 @@ inline Token Lexer::parseAsTime(const std::string& str)
         return Token(TokenType::ERROR, std::string("Invalid token"));
 
     std::tm t;
-    t.tm_sec = ss;
+    t.tm_sec = static_cast<int>(ss);
     t.tm_min = mm;
     t.tm_hour = hh;
     t.tm_mday = DD;

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -289,16 +289,24 @@ inline ParseResult parse(std::istream& is)
     return ParseResult(std::move(v), std::move(parser.errorReason()));
 }
 
-[[noreturn]]
-inline void failwith(const char* reason, ...)
+inline std::string format(std::stringstream &ss)
 {
-    char buf[1024];
-    va_list va;
-    va_start(va, reason);
-    vsnprintf(buf, 1024, reason, va);
-    va_end(va);
+    return ss.str();
+}
 
-    throw std::runtime_error(buf);
+template<typename T, typename... Args>
+std::string format(std::stringstream &ss, T &&t, Args&&... args)
+{
+    ss << std::forward<T>(t);
+    return format(ss, std::forward<Args>(args)...);
+}
+
+template<typename... Args>
+[[noreturn]]
+void failwith(Args&&... args)
+{
+    std::stringstream ss;
+    throw std::runtime_error(format(ss, std::forward<Args>(args)...));
 }
 
 inline std::string removeDelimiter(const std::string& s)
@@ -996,49 +1004,49 @@ template<> inline bool Value::is<Table>() const { return type_ == TABLE_TYPE; }
 template<> inline typename call_traits<bool>::return_type Value::as<bool>() const
 {
     if (!is<bool>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "bool");
+        failwith("type error: this value is ", typeToString(type_), " but bool was requested");
     return bool_;
 }
 template<> inline typename call_traits<int64_t>::return_type Value::as<int64_t>() const
 {
     if (!is<int64_t>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "int64_t");
+        failwith("type error: this value is ", typeToString(type_), " but int64_t was requested");
     return int_;
 }
 template<> inline typename call_traits<int>::return_type Value::as<int>() const
 {
     if (!is<int>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "int");
+        failwith("type error: this value is ", typeToString(type_), " but int was requested");
     return static_cast<int>(int_);
 }
 template<> inline typename call_traits<double>::return_type Value::as<double>() const
 {
     if (!is<double>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "double");
+        failwith("type error: this value is ", typeToString(type_), " but double was requested");
     return double_;
 }
 template<> inline typename call_traits<std::string>::return_type Value::as<std::string>() const
 {
     if (!is<std::string>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "string");
+        failwith("type error: this value is ", typeToString(type_), " but string was requested");
     return *string_;
 }
 template<> inline typename call_traits<Time>::return_type Value::as<Time>() const
 {
     if (!is<Time>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "time");
+        failwith("type error: this value is ", typeToString(type_), " but time was requested");
     return *time_;
 }
 template<> inline typename call_traits<Array>::return_type Value::as<Array>() const
 {
     if (!is<Array>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "array");
+        failwith("type error: this value is ", typeToString(type_), " but array was requested");
     return *array_;
 }
 template<> inline typename call_traits<Table>::return_type Value::as<Table>() const
 {
     if (!is<Table>())
-        failwith("type error: this value is %s but %s was requested", typeToString(type_), "table");
+        failwith("type error: this value is ", typeToString(type_), " but table was requested");
     return *table_;
 }
 
@@ -1054,7 +1062,7 @@ inline double Value::asNumber() const
     if (is<double>())
         return as<double>();
 
-    failwith("type error: this value is %s but number is requested", typeToString(type_));
+    failwith("type error: this value is ", typeToString(type_), " but number is requested");
     return 0.0;
 }
 
@@ -1147,7 +1155,7 @@ inline typename call_traits<T>::return_type Value::get(const std::string& key) c
 
     const Value* obj = find(key);
     if (!obj)
-        failwith("key %s was not found.", key.c_str());
+        failwith("key ", key, " was not found.");
     return obj->as<T>();
 }
 


### PR DESCRIPTION
Hello! In using this library clang produced several warnings which I've addressed. Of note, it looks like in several places the bool Token constructor was being called when likely the string one was desired. The rest of the changes I don't think fix any correctness issues, and mostly were to make clang happy.

If you're interested in reproducing my compiler warning output, I was building with
`-Werror -Wall -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-weak-vtables -Wno-global-constructors -Wno-exit-time-destructors -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-member-function -Wno-switch-enum -Wno-covered-switch-default`