### PR TITLE
Make tinytoml compilable with Visual C++ compiler.

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -20,6 +20,18 @@
 namespace toml
 {
 
+#if defined(_MSC_VER)
+inline time_t timegm(std::tm* timeptr)
+{
+    return _mkgmtime(timeptr);
+}
+inline std::tm* gmtime_r(const time_t* timer, std::tm* result)
+{
+    gmtime_s(result, timer);
+    return result;
+}
+#endif
+
 // ----------------------------------------------------------------------
 // Declarations
 
@@ -305,7 +317,11 @@ std::string format(std::stringstream& ss, T&& t, Args&&... args)
 }
 
 template<typename... Args>
+#if defined(_MSC_VER)
+__declspec(noreturn)
+#else
 [[noreturn]]
+#endif
 void failwith(Args&&... args)
 {
     std::stringstream ss;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,13 +8,15 @@ endif()
 
 enable_testing()
 
-function(add_cxx_flags flags)
-   set(CMAKE_CXX_FLAGS "${flags} ${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
-endfunction()
+if(MSVC)
+    # Use mutli-thread runtime library to match with gtest's one.
+    add_compile_options("/MT$<$<CONFIG:Debug>:d>")
+else()
+    add_compile_options("-Wall" "-Wextra" "-std=c++11")
+endif()
 
-add_cxx_flags("-Wall -Wextra -std=c++11")
-add_cxx_flags("-DSRC_DIR=\\\"${CMAKE_SOURCE_DIR}\\\"")
-add_cxx_flags("-DTESTCASE_DIR=\\\"${CMAKE_SOURCE_DIR}/../testcase\\\"")
+add_definitions(-DSRC_DIR="${CMAKE_SOURCE_DIR}")
+add_definitions(-DTESTCASE_DIR="${CMAKE_SOURCE_DIR}/../testcase")
 
 add_subdirectory(third_party/gtest-1.7.0)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,13 @@ endif()
 
 enable_testing()
 
+if(${CMAKE_VERSION} VERSION_LESS 2.8.12)
+    message("Your cmake version is ${CMAKE_VERSION}. Please update it to 2.8.12 or newer.")
+    function(add_compile_options option)
+        add_definitions(${option} ${ARGN})
+    endfunction()
+endif()
+
 if(MSVC)
     # Use mutli-thread runtime library to match with gtest's one.
     add_compile_options("/MT$<$<CONFIG:Debug>:d>")

--- a/src/parser_complex_test.cc
+++ b/src/parser_complex_test.cc
@@ -115,7 +115,9 @@ TEST(ParserComplexTest, table)
 
     EXPECT_EQ("value", v.get<string>("table.\"127.0.0.1\""));
     EXPECT_EQ("value", v.get<string>("table.\"character encoding\""));
+#if !defined(_MSC_VER)
     EXPECT_EQ("value", v.get<string>("table.\"ʎǝʞ\""));
+#endif
 }
 
 TEST(ParserComplexTest, table_02)
@@ -126,7 +128,9 @@ TEST(ParserComplexTest, table_02)
     EXPECT_EQ(1, v.get<int>("a.b.c.x"));
     EXPECT_EQ(1, v.get<int>("d.e.f.x"));
     EXPECT_EQ(1, v.get<int>("g.h.i.x"));
+#if !defined(_MSC_VER)
     EXPECT_EQ(1, v.get<int>("j.\"ʞ\".l.x"));
+#endif
 }
 
 TEST(ParserComplexTest, table_03)

--- a/src/parser_failure_test.cc
+++ b/src/parser_failure_test.cc
@@ -1,6 +1,10 @@
 #include "toml/toml.h"
 
+#if defined(_MSC_VER)
+#include <windows.h>
+#else
 #include <dirent.h>
+#endif
 
 #include <algorithm>
 #include <fstream>
@@ -15,6 +19,20 @@ namespace {
 
 bool listFiles(const string& path, vector<string>* files)
 {
+#if defined(_MSC_VER)
+    WIN32_FIND_DATA fileData;
+    HANDLE hFind = FindFirstFile(path.c_str(), &fileData);
+    if (hFind == INVALID_HANDLE_VALUE)
+        return false;
+
+    while (true) {
+        files->push_back(fileData.cFileName);
+        if (!FindNextFile(hFind, &fileData))
+            break;
+    }
+    if (FindClose(hFind))
+        return false;
+#else
     DIR* dir = opendir(path.c_str());
     if (!dir)
         return false;
@@ -28,6 +46,7 @@ bool listFiles(const string& path, vector<string>* files)
 
     if (closedir(dir) < 0)
         return false;
+#endif
 
     return true;
 }

--- a/src/parser_test.cc
+++ b/src/parser_test.cc
@@ -6,6 +6,10 @@
 
 using namespace std;
 
+#if defined(_MSC_VER)
+using toml::timegm;
+#endif
+
 static toml::Value parse(const std::string& s)
 {
     stringstream ss(s);


### PR DESCRIPTION
Make tinytoml library compilable with Visual C++ compiler 2015.
What I did in this PR are
- Make some functions to replace with GNU extensions.
- Put some preprocessor directives to replace compiler specific attributes.
- Update CMakeLists.txt to handle compiler options correctly.
- Disable tests with multi-byte characters.  Visual C++ cannot handle UTF8 without BOM.

With this PR, tinytoml can be compiled in DOS prompt.
```
C:\tinytoml>mkdir out
C:\tinytoml>cd out
C:\tinytoml\out>cmake ..\src -G"Visual Studio 14 2015 Win64"
C:\tinytoml\out>cmake --build .
```
