### PR TITLE
Optional indentation + move semantics

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -56,23 +56,6 @@ enum FormatFlag {
     FORMAT_INDENT = 1
 };
 
-// Formatted value to be used when writing to streams
-class FormattedValue
-{
-public:
-    FormattedValue(const Value& value, FormatFlag flags)
-        : value_(value)
-        , flags_(flags)
-    {}
-
-    void write(std::ostream*) const;
-    friend std::ostream& operator<<(std::ostream&, const FormattedValue&);
-
-private:
-    const Value& value_;
-    FormatFlag flags_;
-};
-
 class Value {
 public:
     enum Type {
@@ -173,6 +156,8 @@ public:
     static std::string getIndent(int indent);
 
     void write(std::ostream*, const std::string& keyPrefix = std::string(), int indent = -1) const;
+    void writeFormatted(std::ostream*, FormatFlag flags) const;
+
     friend std::ostream& operator<<(std::ostream&, const Value&);
 
     friend bool operator==(const Value& lhs, const Value& rhs);
@@ -1296,11 +1281,11 @@ inline void Value::write(std::ostream* os, const std::string& keyPrefix, int ind
     }
 }
 
-inline void FormattedValue::write(std::ostream* os) const
+inline void Value::writeFormatted(std::ostream* os, FormatFlag flags) const
 {
-    int indent = flags_ & FORMAT_INDENT ? 0 : -1;
+    int indent = flags & FORMAT_INDENT ? 0 : -1;
 
-    value_.write(os, std::string(), indent);
+    write(os, std::string(), indent);
 }
 
 
@@ -1312,13 +1297,6 @@ inline FormatFlag operator|(FormatFlag lhs, FormatFlag rhs)
 
 // static
 inline std::ostream& operator<<(std::ostream& os, const toml::Value& v)
-{
-    v.write(&os);
-    return os;
-}
-
-// static
-inline std::ostream& operator<<(std::ostream& os, const toml::FormattedValue& v)
 {
     v.write(&os);
     return os;

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -136,7 +136,7 @@ public:
     Value* findChild(const std::string& key);
     const Value* findChild(const std::string& key) const;
     Value* setChild(const std::string& key, const Value& v);
-    Value* setChild(const std::string& key, Value && v);
+    Value* setChild(const std::string& key, Value&& v);
     bool eraseChild(const std::string& key);
 
     // ----------------------------------------------------------------------
@@ -146,7 +146,7 @@ public:
     const Value* find(size_t index) const;
     Value* find(size_t index);
     Value* push(const Value& v);
-    Value* push(Value && v);
+    Value* push(Value&& v);
 
     // ----------------------------------------------------------------------
     // Others
@@ -1405,7 +1405,7 @@ inline Value* Value::setChild(const std::string& key, const Value& v)
     return &(*table_)[key];
 }
 
-inline Value* Value::setChild(const std::string& key, Value && v)
+inline Value* Value::setChild(const std::string& key, Value&& v)
 {
     if (!valid())
         *this = Value((Table()));
@@ -1413,7 +1413,7 @@ inline Value* Value::setChild(const std::string& key, Value && v)
     if (!is<Table>())
         failwith("type must be table to do set(key, v).");
 
-    (*table_)[key] = move(v);
+    (*table_)[key] = std::move(v);
     return &(*table_)[key];
 }
 
@@ -1501,14 +1501,14 @@ inline Value* Value::push(const Value& v)
     return &array_->back();
 }
 
-inline Value* Value::push(Value && v)
+inline Value* Value::push(Value&& v)
 {
     if (!valid())
         *this = Value((Array()));
     else if (!is<Array>())
         failwith("type must be array to do push(Value).");
 
-    array_->push_back(move(v));
+    array_->push_back(std::move(v));
     return &array_->back();
 }
 

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -230,7 +230,7 @@ public:
 
     TokenType type() const { return type_; }
     const std::string& strValue() const { return strValue_; }
-    bool boolValue() const { return intValue_; }
+    bool boolValue() const { return intValue_ != 0; }
     std::int64_t intValue() const { return intValue_; }
     double doubleValue() const { return doubleValue_; }
     std::chrono::system_clock::time_point timeValue() const { return timeValue_; }

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -122,6 +122,7 @@ public:
     Value* findChild(const std::string& key);
     const Value* findChild(const std::string& key) const;
     Value* setChild(const std::string& key, const Value& v);
+    Value* setChild(const std::string& key, Value && v);
     bool eraseChild(const std::string& key);
 
     // For array value
@@ -129,6 +130,7 @@ public:
     const Value* find(size_t index) const;
     Value* find(size_t index);
     Value* push(const Value& v);
+    Value* push(Value && v);
 
     // Writer.
     string getIndent(int indent) const;
@@ -1343,6 +1345,18 @@ inline Value* Value::setChild(const std::string& key, const Value& v)
     return &(*table_)[key];
 }
 
+inline Value* Value::setChild(const std::string& key, Value && v)
+{
+    if (!valid())
+        *this = Value((Table()));
+
+    if (!is<Table>())
+        failwith("type must be table to do set(key, v).");
+
+    (*table_)[key] = move(v);
+    return &(*table_)[key];
+}
+
 inline bool Value::erase(const std::string& key)
 {
     if (!is<Table>())
@@ -1413,6 +1427,17 @@ inline Value* Value::push(const Value& v)
         failwith("type must be array to do push(Value).");
 
     array_->push_back(v);
+    return &array_->back();
+}
+
+inline Value* Value::push(Value && v)
+{
+    if (!valid())
+        *this = Value((Array()));
+    else if (!is<Array>())
+        failwith("type must be array to do push(Value).");
+
+    array_->push_back(move(v));
     return &array_->back();
 }
 

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -152,7 +152,7 @@ public:
     // Others
 
     // Writer.
-    std::string getIndent(int indent) const;
+    static std::string getIndent(int indent);
 
     void write(std::ostream*, int indent = INDENT_DISABLED, const std::string& keyPrefix = std::string()) const;
     friend std::ostream& operator<<(std::ostream&, const Value&);
@@ -1196,14 +1196,9 @@ inline std::time_t Value::as_time_t() const
     return std::chrono::system_clock::to_time_t(as<Time>());
 }
 
-inline std::string Value::getIndent(int indent) const
+inline std::string Value::getIndent(int indent)
 {
-    std::string result;
-
-    while (indent-- > 0)
-        result += "  ";
-
-    return result;
+    return std::string(indent, ' ');
 }
 
 inline void Value::write(std::ostream* os, int indent, const std::string& keyPrefix) const

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -154,7 +154,7 @@ public:
     // Writer.
     static std::string getIndent(int indent);
 
-    void write(std::ostream*, int indent = INDENT_DISABLED, const std::string& keyPrefix = std::string()) const;
+    void write(std::ostream*, const std::string& keyPrefix = std::string(), int indent = INDENT_DISABLED) const;
     friend std::ostream& operator<<(std::ostream&, const Value&);
 
     friend bool operator==(const Value& lhs, const Value& rhs);
@@ -1201,7 +1201,7 @@ inline std::string Value::getIndent(int indent)
     return std::string(indent, ' ');
 }
 
-inline void Value::write(std::ostream* os, int indent, const std::string& keyPrefix) const
+inline void Value::write(std::ostream* os, const std::string& keyPrefix, int indent) const
 {
     switch (type_) {
     case NULL_TYPE:
@@ -1234,7 +1234,7 @@ inline void Value::write(std::ostream* os, int indent, const std::string& keyPre
         for (size_t i = 0; i < array_->size(); ++i) {
             if (i)
                 (*os) << ", ";
-            (*array_)[i].write(os, INDENT_DISABLED, keyPrefix);
+            (*array_)[i].write(os, keyPrefix, INDENT_DISABLED);
         }
         (*os) << ']';
         break;
@@ -1245,7 +1245,7 @@ inline void Value::write(std::ostream* os, int indent, const std::string& keyPre
             if (kv.second.is<Array>() && kv.second.size() > 0 && kv.second.find(0)->is<Table>())
                 continue;
             (*os) << getIndent(indent) << kv.first << " = ";
-            kv.second.write(os, indent >= 0 ? indent + 1 : indent, keyPrefix);
+            kv.second.write(os, keyPrefix, indent >= 0 ? indent + 1 : indent);
             (*os) << '\n';
         }
         for (const auto& kv : *table_) {
@@ -1255,7 +1255,7 @@ inline void Value::write(std::ostream* os, int indent, const std::string& keyPre
                     key += ".";
                 key += kv.first;
                 (*os) << "\n" << getIndent(indent) << "[" << key << "]\n";
-                kv.second.write(os, indent >= 0 ? indent + 1 : indent, key);
+                kv.second.write(os, key, indent >= 0 ? indent + 1 : indent);
             }
             if (kv.second.is<Array>() && kv.second.size() > 0 && kv.second.find(0)->is<Table>()) {
                 std::string key(keyPrefix);
@@ -1264,7 +1264,7 @@ inline void Value::write(std::ostream* os, int indent, const std::string& keyPre
                 key += kv.first;
                 for (const auto& v : kv.second.as<Array>()) {
                     (*os) << "\n" << getIndent(indent) << "[[" << key << "]]\n";
-                    v.write(os, indent >= 0 ? indent + 1 : indent, key);
+                    v.write(os, key, indent >= 0 ? indent + 1 : indent);
                 }
             }
         }


### PR DESCRIPTION
Add the ability to format output with indentation if required.

Example usage:
`value.write(&os, toml::Value::INDENT_ENABLED);`

Also added move semantics for a small performance increase.