### PR TITLE
Expand testsuite with builder/writer tests that enumerate success documents.

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -1,7 +1,9 @@
 #ifndef TINYTOML_H_
 #define TINYTOML_H_
 
+#include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -15,7 +17,6 @@
 #include <map>
 #include <memory>
 #include <utility>
-#include <regex>
 #include <vector>
 
 namespace toml {
@@ -1216,7 +1217,15 @@ inline std::string Value::spaces(int num)
 
 inline std::string Value::escapeKey(const std::string& key)
 {
-    if (!std::regex_match(key, std::regex("^[A-za-z0-9_-]+$")))
+    auto position = std::find_if(key.begin(), key.end(), [](char c) -> bool {
+        if (std::isalnum(c))
+            return false;
+        if (c != '_' && c == '-')
+            return false;
+        return true;
+    });
+
+    if (position != key.end())
     {
         std::string escaped = "\"";
         for (const char& c : key)

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -1225,11 +1225,9 @@ inline std::string Value::escapeKey(const std::string& key)
         return true;
     });
 
-    if (position != key.end())
-    {
+    if (position != key.end()) {
         std::string escaped = "\"";
-        for (const char& c : key)
-        {
+        for (const char& c : key) {
             if (c == '\\' || c  == '"')
                 escaped += '\\';
             escaped += c;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,5 +48,6 @@ add_toml_test(lexer)
 add_toml_test(parser)
 add_toml_test(parser_complex)
 add_toml_test(parser_failure)
+add_toml_test(writer)
 
 add_toml_link_test(link)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,5 +49,6 @@ add_toml_test(parser)
 add_toml_test(parser_complex)
 add_toml_test(parser_failure)
 add_toml_test(writer)
+add_toml_test(builder)
 
 add_toml_link_test(link)

--- a/src/build.h
+++ b/src/build.h
@@ -3,7 +3,7 @@
 
 // Include me last in your _test.cc if you need me.
 
-toml::Value build_array_01(void)
+inline toml::Value build_array_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top= &root;
@@ -70,7 +70,7 @@ toml::Value build_array_01(void)
     return root;
 }
 
-toml::Value build_array_table_01(void)
+inline toml::Value build_array_table_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -111,7 +111,7 @@ toml::Value build_array_table_01(void)
     return root;
 }
 
-toml::Value build_array_table_02(void)
+inline toml::Value build_array_table_02(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -136,7 +136,7 @@ toml::Value build_array_table_02(void)
     return root;
 }
 
-toml::Value build_boolean_01(void)
+inline toml::Value build_boolean_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -149,7 +149,7 @@ toml::Value build_boolean_01(void)
     return root;
 }
 
-toml::Value build_datetime_01(void)
+inline toml::Value build_datetime_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -210,7 +210,7 @@ toml::Value build_datetime_01(void)
     return root;
 }
 
-toml::Value build_float_01(void)
+inline toml::Value build_float_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -236,7 +236,7 @@ toml::Value build_float_01(void)
     return root;
 }
 
-toml::Value build_inlinetable_01(void)
+inline toml::Value build_inlinetable_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -258,7 +258,7 @@ toml::Value build_inlinetable_01(void)
     return root;
 }
 
-toml::Value build_integer_01(void)
+inline toml::Value build_integer_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -277,7 +277,7 @@ toml::Value build_integer_01(void)
     return root;
 }
 
-toml::Value build_string_01(void)
+inline toml::Value build_string_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -307,7 +307,7 @@ toml::Value build_string_01(void)
     return root;
 }
 
-toml::Value build_table_01(void)
+inline toml::Value build_table_01(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -325,7 +325,7 @@ toml::Value build_table_01(void)
     return root;
 }
 
-toml::Value build_table_02(void)
+inline toml::Value build_table_02(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
@@ -358,7 +358,7 @@ toml::Value build_table_02(void)
     return root;
 }
 
-toml::Value build_table_03(void)
+inline toml::Value build_table_03(void)
 {
     toml::Value root((toml::Table()));
     toml::Value* top = &root;

--- a/src/build.h
+++ b/src/build.h
@@ -223,14 +223,15 @@ toml::Value build_float_01(void)
     top->setChild("flt5", 1e6);
     top->setChild("flt6", -2e-2);
 
-    //XXX: Too low? Both writer & parser sets -0 and 0 respectively.
+    // XXX: Too low? Both writer & parser sets -0 and 0 respectively.
     top->setChild("flt7", -6.626e-34);
 
     // XXX: Format: 9_224_617.445_991_228_313
     top->setChild("flt8", 9224617.445991228313);
-    //XXX: Too high? Results in inf for value type double (parser is able. Hmm)
     // XXX: Format: 1e1_000
-    top->setChild("flt9", 1e+1000);
+    // TODO: Express 1e+1000 - sat to zero for now until someone uses this (no test does)
+    // XXX: Too high? Results in inf for value type double (parser is able. Hmm)
+    top->setChild("flt9", 0.0);
 
     return root;
 }

--- a/src/build.h
+++ b/src/build.h
@@ -1,3 +1,5 @@
+#ifndef TOML_TEST_BUILD_H
+#define TOML_TEST_BUILD_H
 
 // Include me last in your _test.cc if you need me.
 
@@ -379,3 +381,6 @@ toml::Value build_table_03(void)
 
     return root;
 }
+
+#endif // TOML_TEST_BUILD_H
+

--- a/src/build.h
+++ b/src/build.h
@@ -1,0 +1,381 @@
+
+// Include me last in your _test.cc if you need me.
+
+toml::Value build_array_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top= &root;
+
+    {
+        auto array = top->setChild("arr1", toml::Array());
+        array->push(1);
+        array->push(2);
+        array->push(3);
+    }
+
+    {
+        auto array = top->setChild("arr2", toml::Array());
+        array->push("red");
+        array->push("yellow");
+        array->push("green");
+    }
+
+    {
+        auto array = top->setChild("arr3", toml::Array());
+        auto nested1 = array->push((toml::Array()));
+        nested1->push(1);
+        nested1->push(2);
+
+        auto nested2 = array->push(toml::Array());
+        nested2->push(3);
+        nested2->push(4);
+        nested2->push(5);
+    }
+
+    {
+        auto array = top->setChild("arr4", toml::Array());
+        array->push("all");
+        array->push("strings");
+        array->push("are the same");
+        array->push("type");
+    }
+
+    {
+        auto array = top->setChild("arr5", toml::Array());
+        auto nested1 = array->push((toml::Array()));
+        nested1->push(1);
+        nested1->push(2);
+
+        auto nested2 = array->push(toml::Array());
+        nested2->push("a");
+        nested2->push("b");
+        nested2->push("c");
+    }
+
+    {
+        auto array = top->setChild("arr7", toml::Array());
+        array->push(1);
+        array->push(2);
+        array->push(3);
+    }
+
+    {
+        auto array = top->setChild("arr8", toml::Array());
+        array->push(1);
+        array->push(2);
+    }
+
+    return root;
+}
+
+toml::Value build_array_table_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    auto widgets = top->setChild("widgets", toml::Array());
+    {
+        auto widget = widgets->push(toml::Table());
+        widget->setChild("type", "image");
+        widget->setChild("width", 1000);
+
+        auto topics = widget->setChild("topics", toml::Array());
+        {
+            auto topic = topics->push(toml::Table());
+            topic->setChild("topic", "some");
+            topic->setChild("count", 3);
+        }
+
+        {
+            auto topic = topics->push(toml::Table());
+            topic->setChild("topic", "something");
+            topic->setChild("count", 4);
+        }
+    }
+
+    {
+        auto widget = widgets->push(toml::Table());
+        widget->setChild("type", "foo");
+        widget->setChild("width", 2000);
+
+        auto topics = widget->setChild("topics", toml::Array());
+        {
+            auto topic = topics->push(toml::Table());
+            topic->setChild("topic", "bar");
+            topic->setChild("count", 5);
+        }
+    }
+
+    return root;
+}
+
+toml::Value build_array_table_02(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    auto widgets = top->setChild("widgets", toml::Table());
+    widgets->setChild("type", "image");
+    widgets->setChild("width", 1000);
+
+    auto topics = widgets->setChild("topics", toml::Array());
+    {
+        auto topic = topics->push(toml::Table());
+        topic->setChild("topic", "some");
+        topic->setChild("count", 3);
+
+    }
+    {
+        auto topic = topics->push(toml::Table());
+        topic->setChild("topic", "something");
+        topic->setChild("count", 4);
+    }
+
+    return root;
+}
+
+toml::Value build_boolean_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    top->setChild("bool1", true);
+    top->setChild("bool2", false);
+    top->setChild("true", true);
+    top->setChild("false", false);
+
+    return root;
+}
+
+toml::Value build_datetime_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    {
+        std::tm t;
+        t.tm_sec = 0;
+        t.tm_min = 32;
+        t.tm_hour = 7;
+        t.tm_mday = 27;
+        t.tm_mon = 5 - 1;
+        t.tm_year = 1979 - 1900;
+        auto tp = std::chrono::system_clock::from_time_t(timegm(&t));
+
+        top->setChild("date1", tp);
+    }
+
+    {
+        std::tm t;
+        t.tm_sec = 0;
+        t.tm_min = 32;
+        t.tm_hour = 0;
+        t.tm_mday = 27;
+        t.tm_mon = 5 - 1;
+        t.tm_year = 1979 - 1900;
+        auto tp = std::chrono::system_clock::from_time_t(timegm(&t));
+
+        top->setChild("date2", tp);
+    }
+
+
+    {
+        std::tm t;
+        t.tm_sec = 0;
+        t.tm_min = 32;
+        t.tm_hour = 0;
+        t.tm_mday = 27;
+        t.tm_mon = 5 - 1;
+        t.tm_year = 1979 - 1900;
+        auto tp = std::chrono::system_clock::from_time_t(timegm(&t));
+
+        top->setChild("date3", tp);
+    }
+
+    {
+        std::tm t;
+        t.tm_sec = 0;
+        t.tm_min = 0;
+        t.tm_hour = 0;
+        t.tm_mday = 27;
+        t.tm_mon = 5 - 1;
+        t.tm_year = 1979 - 1900;
+        auto tp = std::chrono::system_clock::from_time_t(timegm(&t));
+
+        top->setChild("date4", tp);
+    }
+
+    return root;
+}
+
+toml::Value build_float_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    top->setChild("flt1", 1.0);
+    top->setChild("flt2", 3.1415);
+    top->setChild("flt3", -0.01);
+
+    top->setChild("flt4", 5e+22);
+    top->setChild("flt5", 1e6);
+    top->setChild("flt6", -2e-2);
+
+    //XXX: Too low? Both writer & parser sets -0 and 0 respectively.
+    top->setChild("flt7", -6.626e-34);
+
+    // XXX: Format: 9_224_617.445_991_228_313
+    top->setChild("flt8", 9224617.445991228313);
+    //XXX: Too high? Results in inf for value type double (parser is able. Hmm)
+    // XXX: Format: 1e1_000
+    top->setChild("flt9", 1e+1000);
+
+    return root;
+}
+
+toml::Value build_inlinetable_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    {
+        // XXX: format: inline
+        auto table = top->setChild("name", toml::Table());
+        table->setChild("first", "Tom");
+        table->setChild("last", "Preston-Werner");
+    }
+
+    {
+        // XXX: format: inline
+        auto table = top->setChild("point", toml::Table());
+        table->setChild("x", 1);
+        table->setChild("y", 2);
+    }
+
+    return root;
+}
+
+toml::Value build_integer_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    top->setChild("int1", 99);
+    top->setChild("int2", 42);
+    top->setChild("int3", 0);
+    top->setChild("int4", -17);
+    //XXX: format: 1_000
+    top->setChild("int5", 1000);
+    //XXX: format: 5_349_221
+    top->setChild("int6", 5349221);
+    //XXX: format: 1_2_3_4_5
+    top->setChild("int7", 12345);
+
+    return root;
+}
+
+toml::Value build_string_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    top->setChild("s1", "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF.");
+    top->setChild("s2", "Roses are red\nViolets are blue");
+
+    // These three strings are equivalent values, only represented differently on disk (parser).
+    top->setChild("str1", "The quick brown fox jumps over the lazy dog.");
+    top->setChild("str2", "The quick brown fox jumps over the lazy dog.");
+    top->setChild("str3", "The quick brown fox jumps over the lazy dog.");
+
+    // XXX: format: single quote value
+    top->setChild("winpath", "C:\\Users\\nodejs\\templates");
+    // XXX: format: single quote value
+    top->setChild("winpath2", "\\\\ServerX\\admin$\\system32\\");
+    // XXX: format: single quote value
+    top->setChild("quoted", "Tom \"Dubs\" Preston-Werner");
+    // XXX: format: single quote value
+    top->setChild("regex", "<\\i\\c*\\s*>");
+
+    // XXX: format: tripple single quotes: one-line
+    top->setChild("regex2", "I [dw]on't need \\d{2} apples");
+    // XXX: format: tripple single quotes: separate lines
+    top->setChild("lines", "The first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n");
+
+    return root;
+}
+
+toml::Value build_table_01(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    auto table = top->setChild("table", toml::Table());
+    table->setChild("key", "value");
+    table->setChild("bare_key", "value");
+    table->setChild("bare-key", "value");
+    table->setChild("1234", "bare integer");
+
+    table->setChild("127.0.0.1", "value");
+    table->setChild("character encoding", "value");
+    table->setChild("ʎǝʞ", "value");
+
+    return root;
+}
+
+toml::Value build_table_02(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+
+    auto table = top->setChild("table", toml::Table());
+    auto taterman = table->setChild("tater.man", toml::Table());
+
+    taterman->setChild("type", "pug");
+
+    auto a = top->setChild("a", toml::Table());
+    auto b = a->setChild("b", toml::Table());
+    auto c = b->setChild("c", toml::Table());
+    c->setChild("x", 1);
+
+    auto d = top->setChild("d", toml::Table());
+    auto e = d->setChild("e", toml::Table());
+    auto f = e->setChild("f", toml::Table());
+    f->setChild("x", 1);
+
+    auto g = top->setChild("g", toml::Table());
+    auto h = g->setChild("h", toml::Table());
+    auto i = h->setChild("i", toml::Table());
+    i->setChild("x", 1);
+
+    auto j = top->setChild("j", toml::Table());
+    auto k = j->setChild("ʞ", toml::Table());
+    auto l = k->setChild("l", toml::Table());
+    l->setChild("x", 1);
+
+    return root;
+}
+
+toml::Value build_table_03(void)
+{
+    toml::Value root((toml::Table()));
+    toml::Value* top = &root;
+    auto array = top->setChild("a", toml::Array());
+
+    {
+        auto a = array->push(toml::Table());
+
+        auto b = a->setChild("b", toml::Table());
+        b->setChild("x", 1);
+
+    }
+
+    {
+        auto a = array->push(toml::Table());
+
+        auto b = a->setChild("b", toml::Table());
+        b->setChild("x", 2);
+
+    }
+
+    return root;
+}

--- a/src/builder_test.cc
+++ b/src/builder_test.cc
@@ -1,0 +1,106 @@
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "toml/toml.h"
+#include "build.h"
+
+using namespace std;
+
+void compare_content_parsed_from_file (const char *name, toml::Value& value)
+{
+    string filepath = string(TESTCASE_DIR) + "/success/" + name + ".toml";;
+    ifstream file(filepath, ifstream::in);
+    ASSERT_TRUE (file.is_open());
+
+    toml::ParseResult pr = toml::parse(file);
+    ASSERT_TRUE(pr.valid()) << pr.errorReason << file.rdbuf();
+
+    toml::Value& parsed = pr.value;
+    bool result = (parsed == value);
+    EXPECT_TRUE(result);
+
+    if (!result)
+    {
+         std::cout << "VALUE CONTENTS:" << std::endl;
+        value.write(&std::cout);
+        std::cout << "FILE CONTENTS:" << std::endl;
+        parsed.write(&std::cout);
+    }
+}
+
+TEST(BuildTest, build_parse_array_01)
+{
+    toml::Value root = build_array_01();
+    compare_content_parsed_from_file("array-01", root);
+}
+
+TEST(BuildTest, build_parse_array_table_01)
+{
+    toml::Value root = build_array_table_01();
+    compare_content_parsed_from_file("array-table-01", root);
+}
+
+TEST(BuildTest, build_parse_array_table_02)
+{
+    toml::Value root = build_array_table_02();
+    compare_content_parsed_from_file("array-table-02", root);
+}
+
+TEST(BuildTest, build_parse_boolean_01)
+{
+    toml::Value root = build_boolean_01();
+    compare_content_parsed_from_file("boolean-01", root);
+}
+
+TEST(BuildTest, build_parse_datetime_01)
+{
+    toml::Value root = build_datetime_01();
+    compare_content_parsed_from_file("datetime-01", root);
+}
+
+// Unable to properly generate a float-01.toml (yet)
+// TODO: Use test if build_float_01 is able to generate correct state.
+//TEST(BuildTest, build_parse_float_01)
+//{
+//    toml::Value root = build_float_01();
+//    compare_content_parsed_from_file("float-01", root);
+//}
+
+TEST(BuildTest, build_parse_inlinetable_01)
+{
+    toml::Value root = build_inlinetable_01();
+    compare_content_parsed_from_file("inlinetable-01", root);
+}
+
+TEST(BuildTest, build_parse_integer_01)
+{
+    toml::Value root = build_integer_01();
+    compare_content_parsed_from_file("integer-01", root);
+}
+
+TEST(BuildTest, build_parse_string_01)
+{
+    toml::Value root = build_string_01();
+    compare_content_parsed_from_file("string-01", root);
+}
+
+TEST(BuildTest, build_parse_table_01)
+{
+    toml::Value root = build_table_01();
+    compare_content_parsed_from_file("table-01", root);
+}
+
+TEST(BuildTest, build_parse_table_02)
+{
+    toml::Value root = build_table_02();
+    compare_content_parsed_from_file("table-02", root);
+}
+
+TEST(BuildTest, build_parse_table_03)
+{
+    toml::Value root = build_table_03();
+    compare_content_parsed_from_file("table-03", root);
+}
+

--- a/src/builder_test.cc
+++ b/src/builder_test.cc
@@ -21,9 +21,9 @@ void compare_content_parsed_from_file (const char *name, toml::Value& value)
     bool result = (parsed == value);
     EXPECT_TRUE(result);
 
-    if (!result)
+    if (result == false)
     {
-         std::cout << "VALUE CONTENTS:" << std::endl;
+        std::cout << "VALUE CONTENTS:" << std::endl;
         value.write(&std::cout);
         std::cout << "FILE CONTENTS:" << std::endl;
         parsed.write(&std::cout);

--- a/src/builder_test.cc
+++ b/src/builder_test.cc
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-void compare_content_parsed_from_file (const char *name, toml::Value& value)
+void compare_content_parsed_from_file(const char *name, toml::Value& value)
 {
     string filepath = string(TESTCASE_DIR) + "/success/" + name + ".toml";;
     ifstream file(filepath, ifstream::in);

--- a/src/writer_test.cc
+++ b/src/writer_test.cc
@@ -1,0 +1,108 @@
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "toml/toml.h"
+#include "build.h"
+
+using namespace std;
+
+void write_parse_compare (toml::Value& value)
+{
+    // Write value to stringstream
+    stringstream write_ss;
+    value.write(&write_ss);
+
+    // Parse write_ss
+    toml::ParseResult pr = toml::parse(write_ss);
+    ASSERT_TRUE(pr.valid()) << pr.errorReason << write_ss.str();
+
+    // Compare parsed with value
+    toml::Value& parsed = pr.value;
+    bool result = (parsed == value);
+    EXPECT_TRUE(result);
+
+    if (result == false)
+    {
+        std::cout << "VALUE CONTENTS:" << std::endl;
+        value.write(&std::cout);
+        std::cout << "PARSED CONTENTS:" << std::endl;
+        parsed.write(&std::cout);
+    }
+}
+
+TEST(WriterTest, write_parse_array_01)
+{
+    toml::Value root = build_array_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_array_table_01)
+{
+    toml::Value root = build_array_table_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_array_table_02)
+{
+    toml::Value root = build_array_table_02();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_boolean_01)
+{
+    toml::Value root = build_boolean_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_datetime_01)
+{
+    toml::Value root = build_datetime_01();
+    write_parse_compare(root);
+}
+
+// XXX: flt8 generates a comparison error (large floating point...)
+// TODO: Uncomment if fix-able.
+//TEST(WriterTest, write_parse_float_01)
+//{
+//    toml::Value root = build_float_01();
+//    write_parse_compare(root);
+//}
+
+TEST(WriterTest, write_parse_inlinetable_01)
+{
+    toml::Value root = build_inlinetable_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_integer_01)
+{
+    toml::Value root = build_integer_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_string_01)
+{
+    toml::Value root = build_string_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_table_01)
+{
+    toml::Value root = build_table_01();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_table_02)
+{
+    toml::Value root = build_table_02();
+    write_parse_compare(root);
+}
+
+TEST(WriterTest, write_parse_table_03)
+{
+    toml::Value root = build_table_03();
+    write_parse_compare(root);
+}
+


### PR DESCRIPTION
This branch contains two new test executables that test builder/writer interfaces (which, are somewhat lacking..)

Commit 60efde0 fixes proper escaping of keys when outputting the value to ostream.

The builder test (BuilderTest.build_parse_datetime_01) is currently failing. I'm simply assuming this is
due to a parser bug (which I have yet to look into. Priorities..)

I'm in the process of implementing better write support (more formatting options, as well as per Value).
I'm positive this will resolve #11 as well.

Please review and consider merging.