### PR TITLE
Add CTEST_OUTPUT_ON_FAILURE=1 on .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_script:
   - cmake -DCMAKE_BUILD_TYPE=DEBUG ../../src
 
 script:
- - make -j4 && make test
+ - make -j4 
+ - CTEST_OUTPUT_ON_FAILURE=1 make test 


### PR DESCRIPTION
Showing output will help debug when a test failed.