### PR TITLE
Fix a small mistake in judgement of table keys

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -1217,9 +1217,7 @@ inline std::string Value::spaces(int num)
 inline std::string Value::escapeKey(const std::string& key)
 {
     auto position = std::find_if(key.begin(), key.end(), [](char c) -> bool {
-        if (std::isalnum(c))
-            return false;
-        if (c != '_' && c == '-')
+        if (std::isalnum(c) || c == '_' || c == '-')
             return false;
         return true;
     });

--- a/src/writer_test.cc
+++ b/src/writer_test.cc
@@ -100,3 +100,27 @@ TEST(WriterTest, write_parse_table_03)
     toml::Value root = build_table_03();
     write_parse_compare(root);
 }
+
+TEST(WriterTest, write_table_keys)
+{
+    struct {
+        const char* key;
+        const char* expect;
+    } TEST_CASES[] = {
+        {"bare_key", "bare_key"} ,
+        {"barekey", "barekey"},
+        {"bare key", "\"bare key\""},
+        {"bare-key", "bare-key"},
+        {"bareKey", "bareKey"},
+    };
+
+    for (auto testCase : TEST_CASES) {
+        toml::Value root((toml::Table()));
+        root.setChild(testCase.key, "value");
+
+        ostringstream oss;
+        root.write(&oss);
+        string expect = string(testCase.expect) + " = \"value\"\n";
+        EXPECT_EQ(expect, oss.str());
+    }
+}


### PR DESCRIPTION
Current `Value::escapeKey()` has a small issue to escape keys include `'_'`, though it is acceptable in spec.
So what we can choose is either of
1. accept escaping keys with `'_'`.
2. do not escape keys with `'_'`.

If you want 1., we need to remove `c != '_'` on 1222nd line, but I chose 2. with this PR.
I also added a simple test case to check it.

PTL.