### PR TITLE
BREAKING CHANGE: Use std::unordered_map for Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library is distributed under simplified BSD License.
 
 tinytoml is a tiny [TOML](https://github.com/toml-lang/toml) parser for C++11 with following properties:
 - header file only
-- C++11 library friendly (array is std::vector, table is std::map, time is std::chrono::system_clock::time_point).
+- C++11 library friendly (array is `std::vector`, table is `std::unordered_map`, time is `std::chrono::system_clock::time_point`).
 - no external dependencies (note: we're using cmake for testing, but it's not required to use this library).
 
 We'd like to keep this library as handy as possible.

--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -14,8 +14,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <map>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -27,7 +27,7 @@ namespace toml {
 class Value;
 typedef std::chrono::system_clock::time_point Time;
 typedef std::vector<Value> Array;
-typedef std::map<std::string, Value> Table;
+typedef std::unordered_map<std::string, Value> Table;
 
 namespace internal {
 template<typename T> struct call_traits_value {


### PR DESCRIPTION
toml specification does not require table is ordered. In usual case,
std::unordered_map will have better performance

BUG=#21