### PR TITLE
Disable warnings about secure version of buffer-related functions on VC++

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -1,6 +1,12 @@
 #ifndef TINYTOML_H_
 #define TINYTOML_H_
 
+//Disable warning about 'secure' non-portable versions of buffer-related functions
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
+
 #include <algorithm>
 #include <cassert>
 #include <cctype>


### PR DESCRIPTION
Subj.
MS annoys us poor windows users with their non-portable extensions.

I doubt that that it would make much sense to use secure versions, although in some cases it might make sense to read strict number of characters like there https://github.com/mayah/tinytoml/blob/master/include/toml/toml.h#L839