### PR TITLE
gmtime_r workaround for mingw

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -224,15 +224,23 @@ inline time_t timegm(std::tm* timeptr)
 {
     return _mkgmtime(timeptr);
 }
-#endif
-#if defined(_MSC_VER)
-// Visual studio doesn't define gmtime_r, but mingw does
-inline std::tm* gmtime_r(const time_t* timer, std::tm* result)
+
+// On Windows, Visual Studio does not define gmtime_r. However, mingw might
+// do (or might not do). See https://github.com/mayah/tinytoml/issues/25,
+#ifndef gmtime_r
+inline struct tm* gmtime_r(const time_t* t, struct tm* r)
 {
-    gmtime_s(result, timer);
-    return result;
+    // gmtime is threadsafe in windows because it uses TLS
+    struct tm *theTm = gmtime(t);
+    if (theTm) {
+        *r = *theTm;
+        return r;
+    } else {
+        return 0;
+    }
 }
-#endif
+#endif  // gmtime_r
+#endif  // _WIN32
 
 namespace internal {
 

--- a/src/build.h
+++ b/src/build.h
@@ -1,6 +1,11 @@
 #ifndef TOML_TEST_BUILD_H
 #define TOML_TEST_BUILD_H
 
+// Because timegm is defined in toml namespace...
+#if defined(_WIN32)
+using toml::timegm;
+#endif
+
 // Include me last in your _test.cc if you need me.
 
 inline toml::Value build_array_01(void)

--- a/src/parser_complex_test.cc
+++ b/src/parser_complex_test.cc
@@ -9,6 +9,11 @@
 
 using namespace std;
 
+// Because timegm is defined in toml namespace...
+#if defined(_WIN32)
+using toml::timegm;
+#endif
+
 namespace {
 
 toml::Value parse(const string& name)


### PR DESCRIPTION
gmtime_r might be (or might not be) defined in mingw.
Let me try to follow http://redmine.webtoolkit.eu/boards/2/topics/7316
for workaround.

Note that I have not tested with mingw, but I confirmed this builds
with Visual Studio 2017 with cmake.

BUG=#25