### PR TITLE
Fix calls to isalnum() and isalpha() to prevent negative inputs

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -810,7 +810,7 @@ inline Token Lexer::nextKey()
 {
     std::string s;
     char c;
-    while (current(&c) && (isalnum(c) || c == '_' || c == '-')) {
+    while (current(&c) && (isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
         s += c;
         next();
     }
@@ -826,10 +826,10 @@ inline Token Lexer::nextValue()
     std::string s;
     char c;
 
-    if (current(&c) && isalpha(c)) {
+    if (current(&c) && isalpha(static_cast<unsigned char>(c))) {
         s += c;
         next();
-        while (current(&c) && isalpha(c)) {
+        while (current(&c) && isalpha(static_cast<unsigned char>(c))) {
             s += c;
             next();
         }
@@ -1309,7 +1309,7 @@ inline std::string Value::spaces(int num)
 inline std::string Value::escapeKey(const std::string& key)
 {
     auto position = std::find_if(key.begin(), key.end(), [](char c) -> bool {
-        if (std::isalnum(c) || c == '_' || c == '-')
+        if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')
             return false;
         return true;
     });


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/string/byte/isalnum:

> Like all other functions from `<cctype>`, the behavior of `std::isalnum` is undefined if the argument's value is neither representable as unsigned char nor equal to EOF. To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char

This issue was found by the Visual C++ Static Analyzer (/analyze):

```
toml\toml.h(805) : warning C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isalnum'.
toml\toml.h(821) : warning C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isalpha'.
toml\toml.h(824) : warning C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isalpha'.
toml\toml.h(1304) : warning C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isalnum'.
```