### PR TITLE
Cmake build for msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 out
-
+/*build*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
+# Allow IDE's to group targets into folders
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 enable_testing()
 
 if(${CMAKE_VERSION} VERSION_LESS 2.8.12)
@@ -25,24 +28,60 @@ endif()
 add_definitions(-DSRC_DIR="${CMAKE_SOURCE_DIR}")
 add_definitions(-DTESTCASE_DIR="${CMAKE_SOURCE_DIR}/../testcase")
 
+
 add_subdirectory(third_party/gtest-1.7.0)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(../include)
+
+mark_as_advanced(
+gtest_build_samples
+gtest_build_tests
+gtest_disable_pthreads
+gtest_force_shared_crt
+)
+
+set_target_properties(gtest gtest_main 
+    PROPERTIES FOLDER "Third_party")
+
+if(MSVC)
+    if (MSVC_VERSION GREATER_EQUAL 1900)
+        target_compile_definitions(gtest PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+        target_compile_definitions(gtest_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    endif()
+endif()
 
 add_executable(parse_stdin parse_stdin.cc)
 add_executable(parse_file parse_file.cc)
 add_executable(parse_file2 parse_file_2.cc)
 
+if(MSVC)
+	target_compile_definitions(parse_stdin PUBLIC _CRT_SECURE_NO_WARNINGS)
+	target_compile_definitions(parse_file PUBLIC _CRT_SECURE_NO_WARNINGS)
+	target_compile_definitions(parse_file2 PUBLIC _CRT_SECURE_NO_WARNINGS)
+endif()
+
 function(add_toml_test target)
-    add_executable(${target}_test ${target}_test.cc)
+    add_executable(${target}_test ${target}_test.cc ../include/toml/toml.h)
     target_link_libraries(${target}_test gtest gtest_main)
     add_test(${target}_test ${target}_test)
+	set_target_properties(${target}_test
+            PROPERTIES
+            FOLDER "tests")
+	if(MSVC)
+		target_compile_definitions(${target}_test PUBLIC _CRT_SECURE_NO_WARNINGS)
+	endif()
 endfunction()
 
 function(add_toml_link_test target)
-    add_executable(${target}_test ${target}_test.cc empty.cc)
+    add_executable(${target}_test ${target}_test.cc empty.cc ../include/toml/toml.h)
     target_link_libraries(${target}_test gtest gtest_main)
     add_test(${target}_test ${target}_test)
+	set_target_properties(${target}_test
+            PROPERTIES
+            FOLDER "tests")
+	if(MSVC)
+		target_compile_definitions(${target}_test PUBLIC _CRT_SECURE_NO_WARNINGS)
+	endif()
 endfunction()
 
 add_toml_test(value)

--- a/src/build.h
+++ b/src/build.h
@@ -288,7 +288,7 @@ inline toml::Value build_string_01(void)
     toml::Value root((toml::Table()));
     toml::Value* top = &root;
 
-    top->setChild("s1", "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF.");
+    top->setChild("s1", u8"I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF.");
     top->setChild("s2", "Roses are red\nViolets are blue");
 
     // These three strings are equivalent values, only represented differently on disk (parser).

--- a/src/parser_complex_test.cc
+++ b/src/parser_complex_test.cc
@@ -9,14 +9,12 @@
 
 #if defined(_MSC_VER)
 #define timegm _mkgmtime
+#elif defined(_WIN32)
+// Because timegm is defined in toml namespace...
+using toml::timegm;
 #endif
 
 using namespace std;
-
-// Because timegm is defined in toml namespace...
-#if defined(_WIN32)
-using toml::timegm;
-#endif
 
 namespace {
 


### PR DESCRIPTION
If merged this PR will resolve a conflict in parser_complex_test in MSVC 
It also adds folders to the CMAKE build and a few other items to make it easier to work with on Visual Studio and other IDE builds.  

Fix builder_test::build_parse_string_01 which was failing on Visual studio, something with UTF strings, basically made the string literal u8 instead of a regular string literal in the build function.  