### PR TITLE
Fix compiler warning

### DIFF
--- a/include/toml/toml.h
+++ b/include/toml/toml.h
@@ -387,7 +387,7 @@ inline ParseResult parse(std::istream& is)
     if (v.valid())
         return ParseResult(std::move(v), std::string());
 
-    return ParseResult(std::move(v), std::move(parser.errorReason()));
+    return ParseResult(std::move(v), parser.errorReason());
 }
 
 inline ParseResult parseFile(const std::string& filename)


### PR DESCRIPTION
toml.h is used here:
https://github.com/BOINC/boinc/tree/master/samples/docker_wrapper

When compiled on Linux with gcc 14.2.1 the warning below is shown.
This modification avoids the warning.

```
In file included from docker_wrapper.cpp:91:
toml.h: In function ‘toml::ParseResult toml::parse(std::istream&)’:
toml.h:390:47: warning: redundant move in initialization [-Wredundant-move]
  390 |     return ParseResult(std::move(v), std::move(parser.errorReason()));
      |                                      ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
toml.h:390:47: note: remove ‘std::move’ call
```
